### PR TITLE
feat: liste de souhaits avec ajout à la cave

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
   backend-build-dev:
     needs: sonarqube
-    if: github.ref == 'refs/heads/dev' || github.base_ref == 'dev'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
     uses: ./.github/workflows/_backend-build.yml
     with:
       version: ${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
 
   backend-deploy-dev:
     needs: backend-build-dev
-    if: github.ref == 'refs/heads/dev' || github.base_ref == 'dev'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
     uses: ./.github/workflows/_backend-deploy.yml
     with:
       environment: dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Backend and frontend CI/CD
 
 on:
   push:
-    branches: [ main, dev, feature/** ]
+    branches: [ main, dev, feature/**, claude/** ]
   pull_request:
     branches: [ main, dev ]
   workflow_dispatch:

--- a/cavea-back/app/Http/Controllers/WishlistController.php
+++ b/cavea-back/app/Http/Controllers/WishlistController.php
@@ -40,7 +40,7 @@ class WishlistController extends Controller
                 'bottle.region_id'         => 'required|exists:regions,id',
                 'bottle.grape_variety_ids'   => 'nullable|array',
                 'bottle.grape_variety_ids.*' => 'exists:grape_varieties,id',
-                'vintage.year'             => 'required|integer|digits:4|min:1901|max:2026',
+                'vintage.year'             => 'nullable|integer|digits:4|min:1901|max:2026',
                 'appellation_name'         => 'nullable|string|max:255',
             ]);
         } catch (ValidationException $e) {
@@ -75,11 +75,13 @@ class WishlistController extends Controller
                 'grape_variety_ids' => $validated['bottle']['grape_variety_ids'] ?? [],
             ]);
 
-            $vintage = $this->vintageService->findOrCreate($validated['vintage']);
+            $vintage = !empty($validated['vintage']['year'])
+                ? $this->vintageService->findOrCreate($validated['vintage'])
+                : null;
 
             $wishlistItem = $this->wishlistService->create([
                 'bottle_id'      => $bottle->id,
-                'vintage_id'     => $vintage->id,
+                'vintage_id'     => $vintage?->id,
                 'appellation_id' => $appellation?->id,
             ], auth()->id());
 

--- a/cavea-back/app/Http/Controllers/WishlistController.php
+++ b/cavea-back/app/Http/Controllers/WishlistController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+use App\Models\WishlistItem;
+use App\Services\WishlistService;
+use App\Services\BottleService;
+use App\Services\VintageService;
+use App\Services\DomainService;
+use App\Services\AppellationService;
+
+class WishlistController extends Controller
+{
+    public function __construct(
+        protected WishlistService $wishlistService,
+        protected BottleService $bottleService,
+        protected VintageService $vintageService,
+        protected DomainService $domainService,
+        protected AppellationService $appellationService,
+    ) {
+    }
+
+    public function index(): JsonResponse
+    {
+        $items = $this->wishlistService->getUserItems(auth()->id());
+        return response()->json($items);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'bottle.name'              => 'required|string|max:255',
+                'bottle.domain_name'       => 'required|string|max:255',
+                'bottle.colour_id'         => 'required|exists:colours,id',
+                'bottle.region_id'         => 'required|exists:regions,id',
+                'bottle.grape_variety_ids'   => 'nullable|array',
+                'bottle.grape_variety_ids.*' => 'exists:grape_varieties,id',
+                'vintage.year'             => 'required|integer|digits:4|min:1901|max:2026',
+                'appellation_name'         => 'nullable|string|max:255',
+            ]);
+        } catch (ValidationException $e) {
+            Log::error('[WISHLIST_ITEM_POST] Validation failed', [
+                'user_id' => auth()->id(),
+                'errors'  => $e->errors(),
+            ]);
+
+            return response()->json([
+                'message' => 'Les données fournies ne sont pas valides',
+                'errors'  => $e->errors(),
+            ], 422);
+        }
+
+        try {
+            $domain = $this->domainService->findOrCreate([
+                'name' => $validated['bottle']['domain_name'],
+            ]);
+
+            $appellation = null;
+            if (!empty($validated['appellation_name'])) {
+                $appellation = $this->appellationService->findOrCreate([
+                    'name' => $validated['appellation_name'],
+                ]);
+            }
+
+            $bottle = $this->bottleService->findOrCreate([
+                'name'              => $validated['bottle']['name'],
+                'domain_id'         => $domain->id,
+                'colour_id'         => $validated['bottle']['colour_id'],
+                'region_id'         => $validated['bottle']['region_id'],
+                'grape_variety_ids' => $validated['bottle']['grape_variety_ids'] ?? [],
+            ]);
+
+            $vintage = $this->vintageService->findOrCreate($validated['vintage']);
+
+            $wishlistItem = $this->wishlistService->create([
+                'bottle_id'      => $bottle->id,
+                'vintage_id'     => $vintage->id,
+                'appellation_id' => $appellation?->id,
+            ], auth()->id());
+
+            return response()->json($wishlistItem, 201);
+        } catch (\Exception $e) {
+            Log::error('[WISHLIST_ITEM_POST] Error creating wishlist item', [
+                'user_id'       => auth()->id(),
+                'error_message' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'message' => 'Une erreur est survenue lors de l\'ajout à la liste de souhaits.',
+                'error'   => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $wishlistItem = $this->wishlistService->findByIdAndUser($id, auth()->id());
+
+        if (!$wishlistItem) {
+            return response()->json(['message' => 'Élément non trouvé'], 404);
+        }
+
+        return response()->json($wishlistItem);
+    }
+
+    public function destroy(WishlistItem $wishlistItem): JsonResponse
+    {
+        $this->authorize('delete', $wishlistItem);
+
+        $this->wishlistService->delete($wishlistItem);
+        return response()->json(null, 204);
+    }
+}

--- a/cavea-back/app/Models/WishlistItem.php
+++ b/cavea-back/app/Models/WishlistItem.php
@@ -29,7 +29,7 @@ class WishlistItem extends Model
 
     public function vintage(): BelongsTo
     {
-        return $this->belongsTo(Vintage::class);
+        return $this->belongsTo(Vintage::class)->withDefault();
     }
 
     public function appellation(): BelongsTo

--- a/cavea-back/app/Models/WishlistItem.php
+++ b/cavea-back/app/Models/WishlistItem.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WishlistItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'bottle_id',
+        'vintage_id',
+        'appellation_id',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function bottle(): BelongsTo
+    {
+        return $this->belongsTo(Bottle::class);
+    }
+
+    public function vintage(): BelongsTo
+    {
+        return $this->belongsTo(Vintage::class);
+    }
+
+    public function appellation(): BelongsTo
+    {
+        return $this->belongsTo(Appellation::class);
+    }
+}

--- a/cavea-back/app/Models/WishlistItem.php
+++ b/cavea-back/app/Models/WishlistItem.php
@@ -29,7 +29,7 @@ class WishlistItem extends Model
 
     public function vintage(): BelongsTo
     {
-        return $this->belongsTo(Vintage::class)->withDefault();
+        return $this->belongsTo(Vintage::class);
     }
 
     public function appellation(): BelongsTo

--- a/cavea-back/app/Policies/WishlistItemPolicy.php
+++ b/cavea-back/app/Policies/WishlistItemPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WishlistItem;
+
+class WishlistItemPolicy
+{
+    public function view(User $user, WishlistItem $wishlistItem): bool
+    {
+        return $wishlistItem->user_id === $user->id;
+    }
+
+    public function delete(User $user, WishlistItem $wishlistItem): bool
+    {
+        return $wishlistItem->user_id === $user->id;
+    }
+}

--- a/cavea-back/app/Services/WishlistService.php
+++ b/cavea-back/app/Services/WishlistService.php
@@ -40,10 +40,10 @@ class WishlistService
     public function create(array $data, int $userId): WishlistItem
     {
         $wishlistItem = WishlistItem::create([
-            'user_id'         => $userId,
-            'bottle_id'       => $data['bottle_id'],
-            'vintage_id'      => $data['vintage_id'],
-            'appellation_id'  => $data['appellation_id'] ?? null,
+            'user_id'        => $userId,
+            'bottle_id'      => $data['bottle_id'],
+            'vintage_id'     => $data['vintage_id'] ?? null,
+            'appellation_id' => $data['appellation_id'] ?? null,
         ]);
 
         $wishlistItem->load([

--- a/cavea-back/app/Services/WishlistService.php
+++ b/cavea-back/app/Services/WishlistService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WishlistItem;
+use Illuminate\Support\Collection;
+
+class WishlistService
+{
+    public function getUserItems(int $userId): Collection
+    {
+        return WishlistItem::with([
+            'bottle.colour',
+            'bottle.region',
+            'bottle.domain',
+            'bottle.grapeVarieties',
+            'vintage',
+            'appellation',
+        ])
+            ->where('user_id', $userId)
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    public function findByIdAndUser(int $id, int $userId): ?WishlistItem
+    {
+        return WishlistItem::with([
+            'bottle.colour',
+            'bottle.region',
+            'bottle.domain',
+            'bottle.grapeVarieties',
+            'vintage',
+            'appellation',
+        ])
+            ->where('id', $id)
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    public function create(array $data, int $userId): WishlistItem
+    {
+        $wishlistItem = WishlistItem::create([
+            'user_id'         => $userId,
+            'bottle_id'       => $data['bottle_id'],
+            'vintage_id'      => $data['vintage_id'],
+            'appellation_id'  => $data['appellation_id'] ?? null,
+        ]);
+
+        $wishlistItem->load([
+            'bottle.colour',
+            'bottle.region',
+            'bottle.domain',
+            'bottle.grapeVarieties',
+            'vintage',
+            'appellation',
+        ]);
+
+        return $wishlistItem;
+    }
+
+    public function delete(WishlistItem $wishlistItem): void
+    {
+        $wishlistItem->delete();
+    }
+}

--- a/cavea-back/database/factories/WishlistItemFactory.php
+++ b/cavea-back/database/factories/WishlistItemFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\WishlistItem>
+ */
+class WishlistItemFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [];
+    }
+}

--- a/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
+++ b/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wishlist_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('bottle_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('vintage_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('appellation_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wishlist_items');
+    }
+};

--- a/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
+++ b/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('bottle_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('vintage_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('vintage_id')->nullable()->constrained()->nullOnDelete();
             $table->foreignId('appellation_id')->nullable()->constrained()->nullOnDelete();
             $table->timestamps();
         });

--- a/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
+++ b/cavea-back/database/migrations/2026_05_03_000000_create_wishlist_items_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('wishlist_items', function (Blueprint $table) {

--- a/cavea-back/routes/api.php
+++ b/cavea-back/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\CellarItemController;
+use App\Http\Controllers\WishlistController;
 use App\Http\Controllers\EmailVerificationController;
 use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 
@@ -41,4 +42,9 @@ Route::middleware(['auth:sanctum', EnsureEmailIsVerified::class])->group(functio
     Route::delete('/cellar-items/{cellarItem}', [CellarItemController::class, 'destroy']);
     Route::post('/cellar-items/{cellarItem}/comments', [CellarItemController::class, 'storeComment']);
     Route::delete('/cellar-items/{cellarItem}/comments/{comment}', [CellarItemController::class, 'destroyComment']);
+
+    Route::get('/wishlist-items', [WishlistController::class, 'index']);
+    Route::post('/wishlist-items', [WishlistController::class, 'store']);
+    Route::get('/wishlist-items/{wishlistItemId}', [WishlistController::class, 'show']);
+    Route::delete('/wishlist-items/{wishlistItem}', [WishlistController::class, 'destroy']);
 });

--- a/cavea-back/tests/Feature/WishlistControllerTest.php
+++ b/cavea-back/tests/Feature/WishlistControllerTest.php
@@ -160,8 +160,51 @@ class WishlistControllerTest extends TestCase
                  ->assertJsonPath('errors.bottle\.name', fn ($v) => !empty($v))
                  ->assertJsonPath('errors.bottle\.domain_name', fn ($v) => !empty($v))
                  ->assertJsonPath('errors.bottle\.colour_id', fn ($v) => !empty($v))
-                 ->assertJsonPath('errors.bottle\.region_id', fn ($v) => !empty($v))
-                 ->assertJsonPath('errors.vintage\.year', fn ($v) => !empty($v));
+                 ->assertJsonPath('errors.bottle\.region_id', fn ($v) => !empty($v));
+
+        // vintage.year is now optional for wishlist items
+        $response->assertJsonMissingPath('errors.vintage\.year');
+    }
+
+    public function testCanStoreWishlistItemWithoutVintage(): void
+    {
+        $colour  = Colour::factory()->create();
+        $region  = Region::factory()->create();
+        $domain  = Domain::factory()->create();
+        $bottle  = Bottle::factory()->create([
+            'colour_id' => $colour->id,
+            'region_id' => $region->id,
+            'domain_id' => $domain->id,
+        ]);
+
+        $wishlistItem = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->make(['vintage_id' => null]);
+
+        $this->domainService->shouldReceive('findOrCreate')->once()->andReturn($domain);
+        $this->bottleService->shouldReceive('findOrCreate')->once()->andReturn($bottle);
+        $this->vintageService->shouldReceive('findOrCreate')->never();
+
+        $this->wishlistService
+            ->shouldReceive('create')
+            ->once()
+            ->with(
+                Mockery::on(fn ($data) => $data['vintage_id'] === null),
+                $this->user->id
+            )
+            ->andReturn($wishlistItem);
+
+        $response = $this->actingAs($this->user)->postJson('api/wishlist-items', [
+            'bottle' => [
+                'name'        => 'Château Test',
+                'domain_name' => 'Domaine Test',
+                'colour_id'   => $colour->id,
+                'region_id'   => $region->id,
+            ],
+        ]);
+
+        $response->assertCreated();
     }
 
     public function testStoreValidatesVintageYear(): void

--- a/cavea-back/tests/Feature/WishlistControllerTest.php
+++ b/cavea-back/tests/Feature/WishlistControllerTest.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\WishlistItem;
+use App\Models\Bottle;
+use App\Models\Vintage;
+use App\Models\User;
+use App\Models\Colour;
+use App\Models\Region;
+use App\Models\Domain;
+use App\Models\Appellation;
+use App\Services\WishlistService;
+use App\Services\BottleService;
+use App\Services\VintageService;
+use App\Services\DomainService;
+use App\Services\AppellationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+
+class WishlistControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+    protected $wishlistService;
+    protected $bottleService;
+    protected $vintageService;
+    protected $domainService;
+    protected $appellationService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+
+        $this->wishlistService    = Mockery::mock(WishlistService::class);
+        $this->bottleService      = Mockery::mock(BottleService::class);
+        $this->vintageService     = Mockery::mock(VintageService::class);
+        $this->domainService      = Mockery::mock(DomainService::class);
+        $this->appellationService = Mockery::mock(AppellationService::class);
+
+        $this->app->instance(WishlistService::class, $this->wishlistService);
+        $this->app->instance(BottleService::class, $this->bottleService);
+        $this->app->instance(VintageService::class, $this->vintageService);
+        $this->app->instance(DomainService::class, $this->domainService);
+        $this->app->instance(AppellationService::class, $this->appellationService);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testIndexRequiresAuthentication(): void
+    {
+        $response = $this->getJson('api/wishlist-items');
+
+        $response->assertUnauthorized();
+    }
+
+    public function testCanListWishlistItems(): void
+    {
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $this->wishlistService
+            ->shouldReceive('getUserItems')
+            ->once()
+            ->with($this->user->id)
+            ->andReturn(collect([$item->load([
+                'bottle.colour', 'bottle.region', 'bottle.domain',
+                'bottle.grapeVarieties', 'vintage', 'appellation',
+            ])]));
+
+        $response = $this->actingAs($this->user)->getJson('api/wishlist-items');
+
+        $response->assertOk()
+                 ->assertJsonFragment(['id' => $item->id]);
+    }
+
+    public function testCanStoreWishlistItem(): void
+    {
+        $colour  = Colour::factory()->create();
+        $region  = Region::factory()->create();
+        $domain  = Domain::factory()->create();
+        $bottle  = Bottle::factory()->create([
+            'colour_id' => $colour->id,
+            'region_id' => $region->id,
+            'domain_id' => $domain->id,
+        ]);
+        $vintage = Vintage::factory()->create(['year' => 2020]);
+
+        $wishlistItem = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->make();
+
+        $this->domainService
+            ->shouldReceive('findOrCreate')
+            ->once()
+            ->andReturn($domain);
+
+        $this->bottleService
+            ->shouldReceive('findOrCreate')
+            ->once()
+            ->andReturn($bottle);
+
+        $this->vintageService
+            ->shouldReceive('findOrCreate')
+            ->once()
+            ->andReturn($vintage);
+
+        $this->wishlistService
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn($wishlistItem->load([
+                'bottle.colour', 'bottle.region', 'bottle.domain',
+                'bottle.grapeVarieties', 'vintage', 'appellation',
+            ]));
+
+        $payload = [
+            'bottle' => [
+                'name'        => 'Château Test',
+                'domain_name' => 'Domaine Test',
+                'colour_id'   => $colour->id,
+                'region_id'   => $region->id,
+            ],
+            'vintage' => ['year' => 2020],
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('api/wishlist-items', $payload);
+
+        $response->assertCreated();
+    }
+
+    public function testStoreRequiresAuthentication(): void
+    {
+        $response = $this->postJson('api/wishlist-items', []);
+
+        $response->assertUnauthorized();
+    }
+
+    public function testStoreValidatesRequiredFields(): void
+    {
+        $response = $this->actingAs($this->user)->postJson('api/wishlist-items', []);
+
+        $response->assertUnprocessable()
+                 ->assertJsonFragment(['message' => 'Les données fournies ne sont pas valides'])
+                 ->assertJsonPath('errors.bottle\.name', fn ($v) => !empty($v))
+                 ->assertJsonPath('errors.bottle\.domain_name', fn ($v) => !empty($v))
+                 ->assertJsonPath('errors.bottle\.colour_id', fn ($v) => !empty($v))
+                 ->assertJsonPath('errors.bottle\.region_id', fn ($v) => !empty($v))
+                 ->assertJsonPath('errors.vintage\.year', fn ($v) => !empty($v));
+    }
+
+    public function testStoreValidatesVintageYear(): void
+    {
+        $colour = Colour::factory()->create();
+        $region = Region::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson('api/wishlist-items', [
+            'bottle' => [
+                'name'        => 'Test',
+                'domain_name' => 'Domaine Test',
+                'colour_id'   => $colour->id,
+                'region_id'   => $region->id,
+            ],
+            'vintage' => ['year' => 1800],
+        ]);
+
+        $response->assertUnprocessable()
+                 ->assertJsonPath('errors.vintage\.year', fn ($v) => !empty($v));
+    }
+
+    public function testCanShowWishlistItem(): void
+    {
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $this->wishlistService
+            ->shouldReceive('findByIdAndUser')
+            ->once()
+            ->with($item->id, $this->user->id)
+            ->andReturn($item->load([
+                'bottle.colour', 'bottle.region', 'bottle.domain',
+                'bottle.grapeVarieties', 'vintage', 'appellation',
+            ]));
+
+        $response = $this->actingAs($this->user)->getJson("api/wishlist-items/{$item->id}");
+
+        $response->assertOk()
+                 ->assertJsonFragment(['id' => $item->id]);
+    }
+
+    public function testShowReturns404WhenNotFound(): void
+    {
+        $this->wishlistService
+            ->shouldReceive('findByIdAndUser')
+            ->once()
+            ->with(99999, $this->user->id)
+            ->andReturn(null);
+
+        $response = $this->actingAs($this->user)->getJson('api/wishlist-items/99999');
+
+        $response->assertNotFound();
+    }
+
+    public function testShowReturns404ForAnotherUsersItem(): void
+    {
+        $otherUser = User::factory()->create();
+        $bottle    = Bottle::factory()->create();
+        $vintage   = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($otherUser)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $this->wishlistService
+            ->shouldReceive('findByIdAndUser')
+            ->once()
+            ->with($item->id, $this->user->id)
+            ->andReturn(null);
+
+        $response = $this->actingAs($this->user)->getJson("api/wishlist-items/{$item->id}");
+
+        $response->assertNotFound();
+    }
+
+    public function testCanDeleteWishlistItem(): void
+    {
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $this->wishlistService
+            ->shouldReceive('delete')
+            ->once()
+            ->with(Mockery::on(fn ($arg) => $arg->id === $item->id));
+
+        $response = $this->actingAs($this->user)->deleteJson("api/wishlist-items/{$item->id}");
+
+        $response->assertNoContent();
+    }
+
+    public function testDeleteRequiresAuthentication(): void
+    {
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $response = $this->deleteJson("api/wishlist-items/{$item->id}");
+
+        $response->assertUnauthorized();
+    }
+
+    public function testCannotDeleteAnotherUsersWishlistItem(): void
+    {
+        $otherUser = User::factory()->create();
+        $bottle    = Bottle::factory()->create();
+        $vintage   = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()
+            ->for($otherUser)
+            ->for($bottle)
+            ->for($vintage)
+            ->create();
+
+        $response = $this->actingAs($this->user)->deleteJson("api/wishlist-items/{$item->id}");
+
+        $response->assertForbidden();
+    }
+
+    public function testStoreWithAppellationCreatesAppellation(): void
+    {
+        $colour      = Colour::factory()->create();
+        $region      = Region::factory()->create();
+        $domain      = Domain::factory()->create();
+        $bottle      = Bottle::factory()->create([
+            'colour_id' => $colour->id,
+            'region_id' => $region->id,
+            'domain_id' => $domain->id,
+        ]);
+        $vintage     = Vintage::factory()->create(['year' => 2021]);
+        $appellation = Appellation::factory()->create(['name' => 'AOP Languedoc']);
+
+        $wishlistItem = WishlistItem::factory()
+            ->for($this->user)
+            ->for($bottle)
+            ->for($vintage)
+            ->for($appellation)
+            ->make();
+
+        $this->domainService->shouldReceive('findOrCreate')->once()->andReturn($domain);
+        $this->appellationService->shouldReceive('findOrCreate')->once()->andReturn($appellation);
+        $this->bottleService->shouldReceive('findOrCreate')->once()->andReturn($bottle);
+        $this->vintageService->shouldReceive('findOrCreate')->once()->andReturn($vintage);
+
+        $this->wishlistService
+            ->shouldReceive('create')
+            ->once()
+            ->with(
+                Mockery::on(fn ($data) => $data['appellation_id'] === $appellation->id),
+                $this->user->id
+            )
+            ->andReturn($wishlistItem);
+
+        $response = $this->actingAs($this->user)->postJson('api/wishlist-items', [
+            'bottle' => [
+                'name'        => 'Château Test',
+                'domain_name' => 'Domaine Test',
+                'colour_id'   => $colour->id,
+                'region_id'   => $region->id,
+            ],
+            'vintage'          => ['year' => 2021],
+            'appellation_name' => 'AOP Languedoc',
+        ]);
+
+        $response->assertCreated();
+    }
+}

--- a/cavea-back/tests/Feature/WishlistControllerTest.php
+++ b/cavea-back/tests/Feature/WishlistControllerTest.php
@@ -157,13 +157,13 @@ class WishlistControllerTest extends TestCase
 
         $response->assertUnprocessable()
                  ->assertJsonFragment(['message' => 'Les données fournies ne sont pas valides'])
-                 ->assertJsonPath('errors.bottle\.name', fn ($v) => !empty($v))
-                 ->assertJsonPath('errors.bottle\.domain_name', fn ($v) => !empty($v))
-                 ->assertJsonPath('errors.bottle\.colour_id', fn ($v) => !empty($v))
-                 ->assertJsonPath('errors.bottle\.region_id', fn ($v) => !empty($v));
-
-        // vintage.year is now optional for wishlist items
-        $response->assertJsonMissingPath('errors.vintage\.year');
+                 ->assertJsonValidationErrors([
+                     'bottle.name',
+                     'bottle.domain_name',
+                     'bottle.colour_id',
+                     'bottle.region_id',
+                 ])
+                 ->assertJsonMissingValidationErrors(['vintage.year']);
     }
 
     public function testCanStoreWishlistItemWithoutVintage(): void
@@ -223,7 +223,7 @@ class WishlistControllerTest extends TestCase
         ]);
 
         $response->assertUnprocessable()
-                 ->assertJsonPath('errors.vintage\.year', fn ($v) => !empty($v));
+                 ->assertJsonValidationErrors(['vintage.year']);
     }
 
     public function testCanShowWishlistItem(): void

--- a/cavea-back/tests/Unit/WishlistServiceTest.php
+++ b/cavea-back/tests/Unit/WishlistServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\WishlistItem;
+use App\Models\Bottle;
+use App\Models\Vintage;
+use App\Models\User;
+use App\Services\WishlistService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class WishlistServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected WishlistService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new WishlistService();
+    }
+
+    public function testGetUserItemsReturnsOnlyUserItems(): void
+    {
+        $user      = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $bottle    = Bottle::factory()->create();
+        $vintage   = Vintage::factory()->create();
+
+        WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create();
+        WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create();
+        WishlistItem::factory()->for($otherUser)->for($bottle)->for($vintage)->create();
+
+        $items = $this->service->getUserItems($user->id);
+
+        $this->assertCount(2, $items);
+        $items->each(fn ($item) => $this->assertEquals($user->id, $item->user_id));
+    }
+
+    public function testGetUserItemsLoadsRelations(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create();
+
+        $items = $this->service->getUserItems($user->id);
+
+        $this->assertTrue($items->first()->relationLoaded('bottle'));
+        $this->assertTrue($items->first()->relationLoaded('vintage'));
+    }
+
+    public function testGetUserItemsOrderedByCreatedAtDesc(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $first  = WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create(['created_at' => now()->subDay()]);
+        $second = WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create(['created_at' => now()]);
+
+        $items = $this->service->getUserItems($user->id);
+
+        $this->assertEquals($second->id, $items->first()->id);
+        $this->assertEquals($first->id, $items->last()->id);
+    }
+
+    public function testFindByIdAndUserReturnsItemForCorrectUser(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create();
+
+        $found = $this->service->findByIdAndUser($item->id, $user->id);
+
+        $this->assertNotNull($found);
+        $this->assertEquals($item->id, $found->id);
+    }
+
+    public function testFindByIdAndUserReturnsNullForWrongUser(): void
+    {
+        $user      = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $bottle    = Bottle::factory()->create();
+        $vintage   = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()->for($otherUser)->for($bottle)->for($vintage)->create();
+
+        $found = $this->service->findByIdAndUser($item->id, $user->id);
+
+        $this->assertNull($found);
+    }
+
+    public function testFindByIdAndUserReturnsNullWhenNotExists(): void
+    {
+        $user = User::factory()->create();
+
+        $found = $this->service->findByIdAndUser(99999, $user->id);
+
+        $this->assertNull($found);
+    }
+
+    public function testCreatePersistsWishlistItem(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $wishlistItem = $this->service->create([
+            'bottle_id'  => $bottle->id,
+            'vintage_id' => $vintage->id,
+        ], $user->id);
+
+        $this->assertInstanceOf(WishlistItem::class, $wishlistItem);
+        $this->assertEquals($user->id, $wishlistItem->user_id);
+        $this->assertEquals($bottle->id, $wishlistItem->bottle_id);
+        $this->assertEquals($vintage->id, $wishlistItem->vintage_id);
+        $this->assertNull($wishlistItem->appellation_id);
+        $this->assertDatabaseHas('wishlist_items', ['id' => $wishlistItem->id]);
+    }
+
+    public function testCreateWithAppellationId(): void
+    {
+        $user        = User::factory()->create();
+        $bottle      = Bottle::factory()->create();
+        $vintage     = Vintage::factory()->create();
+        $appellation = \App\Models\Appellation::factory()->create();
+
+        $wishlistItem = $this->service->create([
+            'bottle_id'      => $bottle->id,
+            'vintage_id'     => $vintage->id,
+            'appellation_id' => $appellation->id,
+        ], $user->id);
+
+        $this->assertEquals($appellation->id, $wishlistItem->appellation_id);
+    }
+
+    public function testCreateLoadsRelations(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $wishlistItem = $this->service->create([
+            'bottle_id'  => $bottle->id,
+            'vintage_id' => $vintage->id,
+        ], $user->id);
+
+        $this->assertTrue($wishlistItem->relationLoaded('bottle'));
+        $this->assertTrue($wishlistItem->relationLoaded('vintage'));
+        $this->assertTrue($wishlistItem->relationLoaded('appellation'));
+    }
+
+    public function testDeleteRemovesWishlistItem(): void
+    {
+        $user    = User::factory()->create();
+        $bottle  = Bottle::factory()->create();
+        $vintage = Vintage::factory()->create();
+
+        $item = WishlistItem::factory()->for($user)->for($bottle)->for($vintage)->create();
+
+        $this->assertDatabaseHas('wishlist_items', ['id' => $item->id]);
+
+        $this->service->delete($item);
+
+        $this->assertDatabaseMissing('wishlist_items', ['id' => $item->id]);
+    }
+}

--- a/cavea-back/tests/Unit/WishlistServiceTest.php
+++ b/cavea-back/tests/Unit/WishlistServiceTest.php
@@ -124,6 +124,22 @@ class WishlistServiceTest extends TestCase
         $this->assertDatabaseHas('wishlist_items', ['id' => $wishlistItem->id]);
     }
 
+    public function testCreateWithoutVintage(): void
+    {
+        $user   = User::factory()->create();
+        $bottle = Bottle::factory()->create();
+
+        $wishlistItem = $this->service->create([
+            'bottle_id' => $bottle->id,
+        ], $user->id);
+
+        $this->assertNull($wishlistItem->vintage_id);
+        $this->assertDatabaseHas('wishlist_items', [
+            'id'         => $wishlistItem->id,
+            'vintage_id' => null,
+        ]);
+    }
+
     public function testCreateWithAppellationId(): void
     {
         $user        = User::factory()->create();

--- a/cavea-front/app/components/AddOrUpdateBottleForm.tsx
+++ b/cavea-front/app/components/AddOrUpdateBottleForm.tsx
@@ -17,7 +17,7 @@ interface BottleFormData {
     region_id: number;
     grape_variety_ids?: number[];
   };
-  vintage: {
+  vintage?: {
     year: number;
   };
   appellation_name?: string;
@@ -152,7 +152,7 @@ export default function AddOrUpdateBottleForm({
       if (!formData.bottle.region_id) {
         newErrors['bottle.region_id'] = "La région est requise";
       }
-      if (!formData.vintage.year.trim()) {
+      if (mode !== 'wishlist' && !formData.vintage.year.trim()) {
         newErrors['vintage.year'] = "Le millésime est requis";
       }
       if (mode === 'add' && !formData.stock.trim()) {
@@ -204,9 +204,9 @@ export default function AddOrUpdateBottleForm({
             grape_variety_ids: formData.bottle.grape_variety_ids
           }),
         },
-        vintage: {
-          year: parseInt(formData.vintage.year),
-        },
+        ...(formData.vintage.year && {
+          vintage: { year: parseInt(formData.vintage.year) },
+        }),
         ...(mode !== 'wishlist' && { stock: parseInt(formData.stock) }),
         ...(formData.appellation_name && { appellation_name: formData.appellation_name }),
         ...(mode !== 'wishlist' && formData.price && { price: parseFloat(formData.price) }),
@@ -570,9 +570,11 @@ export default function AddOrUpdateBottleForm({
               </>
             ) : null}
 
-            {mode === 'add' && (
+            {(mode === 'add' || mode === 'wishlist') && (
               <>
-                <Text className="text-base font-semibold text-gray mb-2">Millésime *</Text>
+                <Text className="text-base font-semibold text-gray mb-2">
+                  {mode === 'wishlist' ? 'Millésime (optionnel)' : 'Millésime *'}
+                </Text>
                 <TouchableOpacity
                   onPress={() => setYearPickerField('vintage.year')}
                   className="border border-gray-300 rounded-lg px-4 py-3 mb-2 flex-row justify-between items-center"

--- a/cavea-front/app/components/AddOrUpdateBottleForm.tsx
+++ b/cavea-front/app/components/AddOrUpdateBottleForm.tsx
@@ -314,7 +314,7 @@ export default function AddOrUpdateBottleForm({
           <View className="m-6 bg-white p-6 border border-lightgray rounded-lg">
             <Text className="font-bold text-xl pb-4">Informations principales</Text>
             
-            {mode === 'add' ? (
+            {mode !== 'update' ? (
               <>
                 <Text className="text-base font-semibold text-gray mb-2">Nom de la bouteille *</Text>
                 <TextInput placeholderTextColor="#9CA3AF"
@@ -334,7 +334,7 @@ export default function AddOrUpdateBottleForm({
               </>
             )}
 
-            {mode === 'add' ? (
+            {mode !== 'update' ? (
               <>
                 <Text className="text-base font-semibold text-gray mb-2">Domaine *</Text>
                 <TextInput placeholderTextColor="#9CA3AF"
@@ -354,7 +354,7 @@ export default function AddOrUpdateBottleForm({
               </>
             )}
 
-            {mode === 'add' ? (
+            {mode !== 'update' ? (
               <>
                 <Text className="text-base font-semibold text-gray mb-2">Région *</Text>
                 <TouchableOpacity
@@ -537,7 +537,7 @@ export default function AddOrUpdateBottleForm({
               </View>
             </Modal>
 
-            {mode === 'add' ? (
+            {mode !== 'update' ? (
               <>
                 <Text className="text-base font-semibold text-gray mb-2">Couleur *</Text>
                 <TouchableOpacity

--- a/cavea-front/app/components/AddOrUpdateBottleForm.tsx
+++ b/cavea-front/app/components/AddOrUpdateBottleForm.tsx
@@ -21,7 +21,7 @@ interface BottleFormData {
     year: number;
   };
   appellation_name?: string;
-  stock: number;
+  stock?: number;
   price?: number;
   shop?: string;
   offered_by?: string;
@@ -50,7 +50,7 @@ interface BottleFormInput {
 }
 
 interface AddOrUpdateFormProps {
-  mode: 'add' | 'update';
+  mode: 'add' | 'update' | 'wishlist';
   bottleId?: number;
   token?: string;
   initialData?: Partial<BottleFormInput>;
@@ -139,7 +139,7 @@ export default function AddOrUpdateBottleForm({
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
 
-    if (mode === 'add') {
+    if (mode === 'add' || mode === 'wishlist') {
       if (!formData.bottle.name.trim()) {
         newErrors['bottle.name'] = "Le nom de la bouteille est requis";
       }
@@ -155,7 +155,7 @@ export default function AddOrUpdateBottleForm({
       if (!formData.vintage.year.trim()) {
         newErrors['vintage.year'] = "Le millésime est requis";
       }
-      if (!formData.stock.trim()) {
+      if (mode === 'add' && !formData.stock.trim()) {
         newErrors['stock'] = "Le stock est requis";
       }
     }
@@ -200,23 +200,23 @@ export default function AddOrUpdateBottleForm({
           domain_name: formData.bottle.domain_name,
           colour_id: formData.bottle.colour_id!,
           region_id: formData.bottle.region_id!,
-          ...(formData.bottle.grape_variety_ids.length > 0 && { 
-            grape_variety_ids: formData.bottle.grape_variety_ids 
+          ...(formData.bottle.grape_variety_ids.length > 0 && {
+            grape_variety_ids: formData.bottle.grape_variety_ids
           }),
         },
         vintage: {
           year: parseInt(formData.vintage.year),
         },
-        stock: parseInt(formData.stock),
+        ...(mode !== 'wishlist' && { stock: parseInt(formData.stock) }),
         ...(formData.appellation_name && { appellation_name: formData.appellation_name }),
-        ...(formData.price && { price: parseFloat(formData.price) }),
-        ...(formData.shop && { shop: formData.shop }),
-        ...(formData.offered_by && { offered_by: formData.offered_by }),
-        ...(formData.drinking_window_start && { 
-          drinking_window_start: parseInt(formData.drinking_window_start) 
+        ...(mode !== 'wishlist' && formData.price && { price: parseFloat(formData.price) }),
+        ...(mode !== 'wishlist' && formData.shop && { shop: formData.shop }),
+        ...(mode !== 'wishlist' && formData.offered_by && { offered_by: formData.offered_by }),
+        ...(mode !== 'wishlist' && formData.drinking_window_start && {
+          drinking_window_start: parseInt(formData.drinking_window_start)
         }),
-        ...(formData.drinking_window_end && { 
-          drinking_window_end: parseInt(formData.drinking_window_end) 
+        ...(mode !== 'wishlist' && formData.drinking_window_end && {
+          drinking_window_end: parseInt(formData.drinking_window_end)
         }),
       };
       
@@ -292,7 +292,16 @@ export default function AddOrUpdateBottleForm({
         <View className="mb-4">
           <BackButton color="#ffffff" />
         </View>
-        <PageTitle text={mode === 'add' ? 'Ajouter une bouteille' : 'Modifier la bouteille'} color="white" />
+        <PageTitle
+          text={
+            mode === 'add'
+              ? 'Ajouter une bouteille'
+              : mode === 'wishlist'
+              ? 'Ajouter à ma liste'
+              : 'Modifier la bouteille'
+          }
+          color="white"
+        />
       </View>
 
       {dataLoading ? (
@@ -580,7 +589,7 @@ export default function AddOrUpdateBottleForm({
             )}
           </View>
 
-      <View className="m-6 bg-white p-6 border border-lightgray rounded-lg">
+      {mode !== 'wishlist' && <View className="m-6 bg-white p-6 border border-lightgray rounded-lg">
         <Text className="font-bold text-xl pb-4">Informations d'achat</Text>
 
         <View className="flex-row gap-4 mb-4">
@@ -628,9 +637,9 @@ export default function AddOrUpdateBottleForm({
           placeholder="Nom de la personne"
           className="border border-gray-300 rounded-lg px-4 py-3 mb-4"
         />
-      </View>
+      </View>}
 
-      <View className="m-6 bg-white p-6 border border-lightgray rounded-lg">
+      {mode !== 'wishlist' && <View className="m-6 bg-white p-6 border border-lightgray rounded-lg">
         <Text className="font-bold text-xl pb-4">Période de dégustation optimale</Text>
         <View className="flex-row gap-4 mb-4">
           <View className="flex-1">
@@ -661,7 +670,7 @@ export default function AddOrUpdateBottleForm({
         {errors['drinking_window_end'] && (
           <Text className="text-red-600 text-sm mb-4">{errors['drinking_window_end']}</Text>
         )}
-      </View>
+      </View>}
 
         </>
       )}
@@ -672,9 +681,15 @@ export default function AddOrUpdateBottleForm({
             <ActivityIndicator size="large" color="#730b1e" className="my-4" />
           ) : (
             <View className="m-6">
-              <PrimaryButton 
-                text={mode === 'add' ? 'Ajouter' : 'Modifier'} 
-                onPress={handleSubmit} 
+              <PrimaryButton
+                text={
+                  mode === 'add'
+                    ? 'Ajouter'
+                    : mode === 'wishlist'
+                    ? 'Ajouter à ma liste'
+                    : 'Modifier'
+                }
+                onPress={handleSubmit}
               />
             </View>
           )}

--- a/cavea-front/app/components/WishlistCard.tsx
+++ b/cavea-front/app/components/WishlistCard.tsx
@@ -9,7 +9,7 @@ type WishlistCardProps = {
   domainName: string;
   region: string;
   colour: string;
-  vintage: number;
+  vintage?: number | null;
   onAddToCellar: (id: number) => void;
   onDelete: (id: number) => void;
 };
@@ -25,16 +25,26 @@ export default function WishlistCard({
   onDelete,
 }: WishlistCardProps) {
   const iconColor = COLOUR_MAP[colour] || COLOUR_MAP["Autre"];
+  const vintageLabel = vintage ? ` ${vintage}` : '';
+  const fullName = `${bottleName}${vintageLabel}`;
 
   return (
-    <View className="border border-lightgray rounded-lg p-4 bg-white">
-      <View className="flex-row items-center mb-3">
-        <View className="items-center mr-4">
+    <View
+      accessible={false}
+      className="border border-lightgray rounded-lg p-4 bg-white"
+    >
+      <View
+        accessible={true}
+        accessibilityRole="text"
+        accessibilityLabel={`${fullName}, ${domainName}, ${region}, ${colour}`}
+        className="flex-row items-center mb-3"
+      >
+        <View className="items-center mr-4" accessibilityElementsHidden={true} importantForAccessibility="no-hide-descendants">
           <BottleWine size={32} color={iconColor} />
         </View>
         <View className="flex-1">
           <Text className="text-base font-semibold text-black">
-            {bottleName} {vintage}
+            {bottleName}{vintage ? ` ${vintage}` : ''}
           </Text>
           <Text className="text-sm text-gray">{domainName}</Text>
           <Text className="text-sm text-gray">{region}</Text>
@@ -46,18 +56,26 @@ export default function WishlistCard({
         <TouchableOpacity
           onPress={() => onAddToCellar(id)}
           testID={`add-to-cellar-${id}`}
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel={`Ajouter ${fullName} à ma cave`}
+          accessibilityHint="Ouvre le formulaire d'ajout pré-rempli avec les informations de ce vin"
           className="flex-1 flex-row items-center justify-center gap-2 bg-wine py-2 rounded-lg"
         >
-          <ShoppingBag size={16} color="#ffffff" />
+          <ShoppingBag size={16} color="#ffffff" accessibilityElementsHidden={true} />
           <Text className="text-white text-sm font-semibold">Ajouter à ma cave</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
           onPress={() => onDelete(id)}
           testID={`delete-wishlist-${id}`}
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel={`Supprimer ${fullName} de la liste de souhaits`}
+          accessibilityHint="Retire ce vin de votre liste de souhaits"
           className="flex-row items-center justify-center px-4 py-2 border border-lightgray rounded-lg"
         >
-          <Trash2 size={16} color="#730b1e" />
+          <Trash2 size={16} color="#730b1e" accessibilityElementsHidden={true} />
         </TouchableOpacity>
       </View>
     </View>

--- a/cavea-front/app/components/WishlistCard.tsx
+++ b/cavea-front/app/components/WishlistCard.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { BottleWine, Trash2, ShoppingBag } from "lucide-react-native";
+import { COLOUR_MAP } from "@/constants/wineData";
+
+type WishlistCardProps = {
+  id: number;
+  bottleName: string;
+  domainName: string;
+  region: string;
+  colour: string;
+  vintage: number;
+  onAddToCellar: (id: number) => void;
+  onDelete: (id: number) => void;
+};
+
+export default function WishlistCard({
+  id,
+  bottleName,
+  domainName,
+  region,
+  colour,
+  vintage,
+  onAddToCellar,
+  onDelete,
+}: WishlistCardProps) {
+  const iconColor = COLOUR_MAP[colour] || COLOUR_MAP["Autre"];
+
+  return (
+    <View className="border border-lightgray rounded-lg p-4 bg-white">
+      <View className="flex-row items-center mb-3">
+        <View className="items-center mr-4">
+          <BottleWine size={32} color={iconColor} />
+        </View>
+        <View className="flex-1">
+          <Text className="text-base font-semibold text-black">
+            {bottleName} {vintage}
+          </Text>
+          <Text className="text-sm text-gray">{domainName}</Text>
+          <Text className="text-sm text-gray">{region}</Text>
+          <Text className="text-xs text-gray mt-1">{colour}</Text>
+        </View>
+      </View>
+
+      <View className="flex-row gap-3 mt-1">
+        <TouchableOpacity
+          onPress={() => onAddToCellar(id)}
+          testID={`add-to-cellar-${id}`}
+          className="flex-1 flex-row items-center justify-center gap-2 bg-wine py-2 rounded-lg"
+        >
+          <ShoppingBag size={16} color="#ffffff" />
+          <Text className="text-white text-sm font-semibold">Ajouter à ma cave</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onDelete(id)}
+          testID={`delete-wishlist-${id}`}
+          className="flex-row items-center justify-center px-4 py-2 border border-lightgray rounded-lg"
+        >
+          <Trash2 size={16} color="#730b1e" />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/cavea-front/app/components/__tests__/AddOrUpdateBottleForm.test.tsx
+++ b/cavea-front/app/components/__tests__/AddOrUpdateBottleForm.test.tsx
@@ -58,6 +58,92 @@ describe('AddOrUpdateBottleForm', () => {
     });
   });
 
+  describe('Rendering in WISHLIST mode', () => {
+    it('should render editable fields for name, domain and region', () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByPlaceholderText("Ex: A l'ombre du figuier")).toBeTruthy();
+      expect(screen.getByPlaceholderText('Ex: Mas de la Seranne')).toBeTruthy();
+      expect(screen.getByText('Sélectionnez une région')).toBeTruthy();
+    });
+
+    it('should show colour picker in wishlist mode', () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByText('Sélectionnez une couleur')).toBeTruthy();
+    });
+
+    it('should show optional vintage label in wishlist mode', () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByText('Millésime (optionnel)')).toBeTruthy();
+    });
+
+    it('should render "Ajouter à ma liste" button in wishlist mode', () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      // The text appears in both the page title and the submit button
+      expect(screen.getAllByText('Ajouter à ma liste').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should not show stock or price fields in wishlist mode', () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.queryByPlaceholderText('Ex: 6')).toBeNull();
+      expect(screen.queryByPlaceholderText('Ex: 15.50')).toBeNull();
+    });
+
+    it('should submit without vintage when year is not set', async () => {
+      render(
+        <AddOrUpdateBottleForm
+          mode="wishlist"
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.changeText(screen.getByPlaceholderText("Ex: A l'ombre du figuier"), 'Château Test');
+      fireEvent.changeText(screen.getByPlaceholderText('Ex: Mas de la Seranne'), 'Domaine Test');
+      fireEvent.press(screen.getByText('Sélectionnez une couleur'));
+      fireEvent.press(screen.getByText('Rouge'));
+      fireEvent.press(screen.getByText('Sélectionnez une région'));
+      fireEvent.press(screen.getByText('Bordeaux'));
+
+      // Use the last occurrence (submit button), the first is the page title
+      fireEvent.press(screen.getAllByText('Ajouter à ma liste').at(-1)!);
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.not.objectContaining({ vintage: expect.anything() })
+        );
+      });
+    });
+  });
+
   describe('Form validation', () => {
     it('should show error when submitting without required fields', async () => {
       render(

--- a/cavea-front/app/components/__tests__/WishlistCard.test.tsx
+++ b/cavea-front/app/components/__tests__/WishlistCard.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import WishlistCard from '../WishlistCard';
+
+jest.mock('lucide-react-native', () => ({
+  BottleWine: () => null,
+  Trash2: () => null,
+  ShoppingBag: () => null,
+}));
+
+const defaultProps = {
+  id: 1,
+  bottleName: 'Château Margaux',
+  domainName: 'Château Margaux SCA',
+  region: 'Bordeaux',
+  colour: 'Rouge',
+  vintage: 2018,
+  onAddToCellar: jest.fn(),
+  onDelete: jest.fn(),
+};
+
+describe('WishlistCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should render bottle name and vintage', () => {
+    render(<WishlistCard {...defaultProps} />);
+    expect(screen.getByText('Château Margaux 2018')).toBeTruthy();
+  });
+
+  it('should render domain name', () => {
+    render(<WishlistCard {...defaultProps} />);
+    expect(screen.getByText('Château Margaux SCA')).toBeTruthy();
+  });
+
+  it('should render region', () => {
+    render(<WishlistCard {...defaultProps} />);
+    expect(screen.getByText('Bordeaux')).toBeTruthy();
+  });
+
+  it('should render colour', () => {
+    render(<WishlistCard {...defaultProps} />);
+    expect(screen.getByText('Rouge')).toBeTruthy();
+  });
+
+  it('should call onAddToCellar with id when add-to-cellar button is pressed', () => {
+    render(<WishlistCard {...defaultProps} />);
+    fireEvent.press(screen.getByTestId('add-to-cellar-1'));
+    expect(defaultProps.onAddToCellar).toHaveBeenCalledWith(1);
+  });
+
+  it('should call onDelete with id when delete button is pressed', () => {
+    render(<WishlistCard {...defaultProps} />);
+    fireEvent.press(screen.getByTestId('delete-wishlist-1'));
+    expect(defaultProps.onDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('should use correct testIDs based on id prop', () => {
+    render(<WishlistCard {...defaultProps} id={42} />);
+    expect(screen.getByTestId('add-to-cellar-42')).toBeTruthy();
+    expect(screen.getByTestId('delete-wishlist-42')).toBeTruthy();
+  });
+});

--- a/cavea-front/app/protected/__tests__/add-bottle.test.tsx
+++ b/cavea-front/app/protected/__tests__/add-bottle.test.tsx
@@ -11,6 +11,7 @@ jest.mock('expo-router', () => ({
   useFocusEffect: (callback: () => void) => {
     require('react').useEffect(callback, []);
   },
+  useLocalSearchParams: jest.fn(() => ({})),
 }));
 
 jest.mock('@/authentication/AuthContext', () => ({
@@ -20,6 +21,13 @@ jest.mock('@/authentication/AuthContext', () => ({
 jest.mock('@/services/CellarService', () => ({
   cellarService: {
     createCellarItem: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/WishlistService', () => ({
+  wishlistService: {
+    getWishlistItemById: jest.fn(),
+    deleteWishlistItem: jest.fn(),
   },
 }));
 

--- a/cavea-front/app/protected/__tests__/add-bottle.test.tsx
+++ b/cavea-front/app/protected/__tests__/add-bottle.test.tsx
@@ -11,7 +11,6 @@ jest.mock('expo-router', () => ({
   useFocusEffect: (callback: () => void) => {
     require('react').useEffect(callback, []);
   },
-  useLocalSearchParams: jest.fn(() => ({})),
 }));
 
 jest.mock('@/authentication/AuthContext', () => ({
@@ -21,13 +20,6 @@ jest.mock('@/authentication/AuthContext', () => ({
 jest.mock('@/services/CellarService', () => ({
   cellarService: {
     createCellarItem: jest.fn(),
-  },
-}));
-
-jest.mock('@/services/WishlistService', () => ({
-  wishlistService: {
-    getWishlistItemById: jest.fn(),
-    deleteWishlistItem: jest.fn(),
   },
 }));
 

--- a/cavea-front/app/protected/__tests__/add-from-wishlist.test.tsx
+++ b/cavea-front/app/protected/__tests__/add-from-wishlist.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import AddFromWishlistPage from '../add-from-wishlist';
+import { wishlistService } from '@/services/WishlistService';
+import { cellarService } from '@/services/CellarService';
+
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: jest.fn(),
+  useLocalSearchParams: jest.fn(() => ({ id: '5' })),
+}));
+
+jest.mock('@/authentication/AuthContext', () => ({
+  useAuth: jest.fn(() => ({ token: 'mock-token' })),
+}));
+
+jest.mock('@/services/WishlistService', () => ({
+  wishlistService: {
+    getWishlistItemById: jest.fn(),
+    deleteWishlistItem: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/CellarService', () => ({
+  cellarService: {
+    createCellarItem: jest.fn(),
+  },
+}));
+
+jest.mock('@/app/components/AddOrUpdateBottleForm', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockWishlistItem = {
+  bottle: {
+    name: 'Château Test',
+    domain: { name: 'Domaine Test' },
+    colour: { id: 1, name: 'Rouge' },
+    region: { id: 3, name: 'Bordeaux' },
+    grapeVarieties: [],
+  },
+  vintage: { year: 2020 },
+  appellation: { name: 'AOP Bordeaux' },
+};
+
+describe('AddFromWishlistPage', () => {
+  let alertSpy: jest.SpyInstance;
+  let mockCapturedSubmit: ((formData: any) => Promise<void>) | null = null;
+  const { useRouter } = require('expo-router');
+  const { useAuth } = require('@/authentication/AuthContext');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCapturedSubmit = null;
+    useRouter.mockReturnValue({ replace: mockReplace, back: mockBack });
+    useAuth.mockReturnValue({ token: 'mock-token' });
+    alertSpy = jest.spyOn(Alert, 'alert');
+
+    const MockForm = require('@/app/components/AddOrUpdateBottleForm').default;
+    (MockForm as jest.Mock).mockImplementation((props: any) => {
+      mockCapturedSubmit = props.onSubmit;
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  it('should show loading indicator while fetching wishlist item', () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    const { getByRole } = render(<AddFromWishlistPage />);
+    expect(getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('should hide loading indicator and render form after fetch', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockResolvedValue(mockWishlistItem);
+
+    const MockForm = require('@/app/components/AddOrUpdateBottleForm').default;
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(MockForm).toHaveBeenCalled());
+
+    const receivedProps = (MockForm as jest.Mock).mock.calls.at(-1)[0];
+    expect(receivedProps.mode).toBe('add');
+    expect(receivedProps.initialData).toMatchObject({
+      bottle: {
+        name: 'Château Test',
+        domain_name: 'Domaine Test',
+        colour_id: 1,
+        region_id: 3,
+      },
+      vintage: { year: '2020' },
+      appellation_name: 'AOP Bordeaux',
+    });
+  });
+
+  it('should pre-fill without vintage when wishlist item has no vintage', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockResolvedValue({
+      ...mockWishlistItem,
+      vintage: null,
+    });
+
+    const MockForm = require('@/app/components/AddOrUpdateBottleForm').default;
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(MockForm).toHaveBeenCalled());
+
+    const receivedProps = (MockForm as jest.Mock).mock.calls.at(-1)[0];
+    expect(receivedProps.initialData).not.toHaveProperty('vintage');
+  });
+
+  it('should show error alert and navigate back on fetch failure', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockRejectedValue(
+      new Error('Network error')
+    );
+
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Erreur',
+        'Impossible de charger les données du vin',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('should add to cellar and delete wishlist item on successful submit', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockResolvedValue(mockWishlistItem);
+    (cellarService.createCellarItem as jest.Mock).mockResolvedValue({ id: 10 });
+    (wishlistService.deleteWishlistItem as jest.Mock).mockResolvedValue(undefined);
+
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(mockCapturedSubmit).not.toBeNull());
+
+    await mockCapturedSubmit!({ bottle: { name: 'Château Test' }, stock: 2 });
+
+    await waitFor(() => {
+      expect(cellarService.createCellarItem).toHaveBeenCalledWith(
+        'mock-token',
+        { bottle: { name: 'Château Test' }, stock: 2 }
+      );
+      expect(wishlistService.deleteWishlistItem).toHaveBeenCalledWith('mock-token', 5);
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Succès',
+        'Bouteille ajoutée à votre cave !',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('should navigate to dashboard after pressing OK on success', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockResolvedValue(mockWishlistItem);
+    (cellarService.createCellarItem as jest.Mock).mockResolvedValue({ id: 10 });
+    (wishlistService.deleteWishlistItem as jest.Mock).mockResolvedValue(undefined);
+
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(mockCapturedSubmit).not.toBeNull());
+    await mockCapturedSubmit!({ stock: 1 });
+
+    await waitFor(() => {
+      const okButton = alertSpy.mock.calls[0][2][0];
+      okButton.onPress();
+      expect(mockReplace).toHaveBeenCalledWith('/protected/dashboard');
+    });
+  });
+
+  it('should show error alert when no token', async () => {
+    useAuth.mockReturnValue({ token: null });
+
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(mockCapturedSubmit).not.toBeNull());
+    await mockCapturedSubmit!({});
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Erreur', 'Vous devez être connecté');
+    });
+  });
+
+  it('should show formatted validation errors on 422', async () => {
+    (wishlistService.getWishlistItemById as jest.Mock).mockResolvedValue(mockWishlistItem);
+    (cellarService.createCellarItem as jest.Mock).mockRejectedValue({
+      response: { status: 422, data: { errors: { stock: ['Le stock est requis'] } } },
+    });
+
+    render(<AddFromWishlistPage />);
+
+    await waitFor(() => expect(mockCapturedSubmit).not.toBeNull());
+    await mockCapturedSubmit!({});
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Erreur',
+        expect.stringContaining('Le stock est requis')
+      );
+    });
+  });
+});

--- a/cavea-front/app/protected/__tests__/wishlist.test.tsx
+++ b/cavea-front/app/protected/__tests__/wishlist.test.tsx
@@ -164,7 +164,7 @@ describe('WishlistPage', () => {
     expect(mockPush).toHaveBeenCalledWith('/protected/add-wishlist-item');
   });
 
-  it('should navigate to add-bottle with fromWishlistId when add-to-cellar is pressed', async () => {
+  it('should navigate to add-from-wishlist with id when add-to-cellar is pressed', async () => {
     (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue(mockItems);
 
     render(<WishlistPage />);
@@ -177,8 +177,8 @@ describe('WishlistPage', () => {
 
     expect(mockPush).toHaveBeenCalledWith(
       expect.objectContaining({
-        pathname: '/protected/add-bottle',
-        params: { fromWishlistId: 1 },
+        pathname: '/protected/add-from-wishlist',
+        params: { id: 1 },
       })
     );
   });

--- a/cavea-front/app/protected/__tests__/wishlist.test.tsx
+++ b/cavea-front/app/protected/__tests__/wishlist.test.tsx
@@ -1,48 +1,198 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react-native';
 import WishlistPage from '../wishlist';
+import { wishlistService } from '@/services/WishlistService';
 
-jest.mock('../../components/PageTitle', () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock('expo-router', () => ({
+  useFocusEffect: (callback: () => void) => {
+    require('react').useEffect(callback, [callback]);
+  },
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
 }));
 
-jest.mock('lucide-react-native', () => ({
-  Heart: jest.fn(() => null),
+jest.mock('@/authentication/AuthContext', () => ({
+  useAuth: () => ({ token: 'mock-token' }),
 }));
+
+jest.mock('@/services/WishlistService', () => ({
+  wishlistService: {
+    getWishlistItems: jest.fn(),
+    deleteWishlistItem: jest.fn(),
+  },
+}));
+
+jest.mock('../../components/OfflineIndicator', () => () => null);
+jest.mock('../../components/WishlistCard', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../components/PrimaryButton', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../components/PageTitle', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('lucide-react-native', () => ({ Heart: jest.fn(() => null) }));
+
+const mockItems = [
+  {
+    id: 1,
+    bottle: {
+      name: 'Château Test',
+      domain: { name: 'Domaine Test' },
+      region: { name: 'Bordeaux' },
+      colour: { id: 1, name: 'Rouge' },
+    },
+    vintage: { year: 2020 },
+    appellation: null,
+  },
+  {
+    id: 2,
+    bottle: {
+      name: 'Clos du Roy',
+      domain: { name: 'Domaine Roy' },
+      region: { name: 'Bourgogne' },
+      colour: { id: 2, name: 'Blanc' },
+    },
+    vintage: { year: 2019 },
+    appellation: { name: 'AOP Bourgogne' },
+  },
+];
 
 describe('WishlistPage', () => {
+  let mockPush: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPush = jest.fn();
+
+    const expoRouter = require('expo-router');
+    jest.spyOn(expoRouter, 'useRouter').mockReturnValue({
+      push: mockPush,
+      replace: jest.fn(),
+      back: jest.fn(),
+    });
+
     const MockPageTitle = require('../../components/PageTitle').default;
     (MockPageTitle as jest.Mock).mockImplementation(({ text }: { text: string }) => {
-      const React = require('react');
+      const R = require('react');
       const { Text } = require('react-native');
-      return React.createElement(Text, null, text);
+      return R.createElement(Text, null, text);
     });
+
+    const MockPrimaryButton = require('../../components/PrimaryButton').default;
+    (MockPrimaryButton as jest.Mock).mockImplementation(({ text, onPress }: any) => {
+      const R = require('react');
+      const { TouchableOpacity, Text } = require('react-native');
+      return R.createElement(
+        TouchableOpacity,
+        { onPress, testID: 'primary-button' },
+        R.createElement(Text, null, text)
+      );
+    });
+
+    const MockWishlistCard = require('../../components/WishlistCard').default;
+    (MockWishlistCard as jest.Mock).mockImplementation(
+      ({ bottleName, vintage, onAddToCellar, onDelete, id }: any) => {
+        const R = require('react');
+        const { View, Text, TouchableOpacity } = require('react-native');
+        return R.createElement(
+          View,
+          null,
+          R.createElement(Text, null, `${bottleName} ${vintage}`),
+          R.createElement(
+            TouchableOpacity,
+            { testID: `add-to-cellar-${id}`, onPress: () => onAddToCellar(id) },
+            R.createElement(Text, null, 'Ajouter à ma cave')
+          ),
+          R.createElement(
+            TouchableOpacity,
+            { testID: `delete-wishlist-${id}`, onPress: () => onDelete(id) },
+            R.createElement(Text, null, 'Supprimer')
+          )
+        );
+      }
+    );
   });
 
-  it('should render the page title', () => {
+  it('should display the page title', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue([]);
     render(<WishlistPage />);
     expect(screen.getByText('Ma liste de souhaits')).toBeTruthy();
   });
 
-  it('should render the subtitle', () => {
+  it('should display the subtitle', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue([]);
     render(<WishlistPage />);
     expect(screen.getByText('Les vins qui me font rêver !')).toBeTruthy();
   });
 
-  it('should render the coming soon message', () => {
+  it('should display empty state when wishlist is empty', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue([]);
+
     render(<WishlistPage />);
-    expect(screen.getByText('Bientôt disponible')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText('Votre liste est vide')).toBeTruthy();
+    });
   });
 
-  it('should render the teasing description', () => {
+  it('should display wishlist items after loading', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue(mockItems);
+
     render(<WishlistPage />);
-    expect(
-      screen.getByText(
-        'Gardez une trace des vins qui vous font envie et ne ratez plus jamais une belle bouteille.'
-      )
-    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText('Château Test 2020')).toBeTruthy();
+      expect(screen.getByText('Clos du Roy 2019')).toBeTruthy();
+    });
+  });
+
+  it('should call getWishlistItems with token on mount', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue([]);
+
+    render(<WishlistPage />);
+
+    await waitFor(() => {
+      expect(wishlistService.getWishlistItems).toHaveBeenCalledWith('mock-token');
+    });
+  });
+
+  it('should navigate to add-wishlist-item when add button is pressed', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue([]);
+
+    render(<WishlistPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('primary-button')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId('primary-button'));
+    expect(mockPush).toHaveBeenCalledWith('/protected/add-wishlist-item');
+  });
+
+  it('should navigate to add-bottle with fromWishlistId when add-to-cellar is pressed', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockResolvedValue(mockItems);
+
+    render(<WishlistPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('add-to-cellar-1')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId('add-to-cellar-1'));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/protected/add-bottle',
+        params: { fromWishlistId: 1 },
+      })
+    );
+  });
+
+  it('should handle fetch error gracefully', async () => {
+    (wishlistService.getWishlistItems as jest.Mock).mockRejectedValue(new Error('Network error'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    render(<WishlistPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Votre liste est vide')).toBeTruthy();
+    });
+
+    consoleError.mockRestore();
   });
 });

--- a/cavea-front/app/protected/_layout.tsx
+++ b/cavea-front/app/protected/_layout.tsx
@@ -101,6 +101,13 @@ export default function TabsLayout() {
           href: null,
         }}
       />
+
+      <Tabs.Screen
+        name="add-wishlist-item"
+        options={{
+          href: null,
+        }}
+      />
     </Tabs>
   );
 }

--- a/cavea-front/app/protected/_layout.tsx
+++ b/cavea-front/app/protected/_layout.tsx
@@ -108,6 +108,13 @@ export default function TabsLayout() {
           href: null,
         }}
       />
+
+      <Tabs.Screen
+        name="add-from-wishlist"
+        options={{
+          href: null,
+        }}
+      />
     </Tabs>
   );
 }

--- a/cavea-front/app/protected/add-bottle.tsx
+++ b/cavea-front/app/protected/add-bottle.tsx
@@ -1,55 +1,20 @@
-import { ScrollView, Alert, ActivityIndicator, View } from "react-native";
-import { useRouter, useFocusEffect, useLocalSearchParams } from "expo-router";
-import { useState, useCallback, useEffect } from "react";
+import { ScrollView, Alert } from "react-native";
+import { useRouter, useFocusEffect } from "expo-router";
+import { useState, useCallback } from "react";
 import { useAuth } from "@/authentication/AuthContext";
 import AddOrUpdateBottleForm from "../components/AddOrUpdateBottleForm";
 import { cellarService } from "@/services/CellarService";
-import { wishlistService } from "@/services/WishlistService";
 
 export default function AddBottlePage() {
   const router = useRouter();
   const { token } = useAuth();
-  const { fromWishlistId } = useLocalSearchParams<{ fromWishlistId?: string }>();
   const [formKey, setFormKey] = useState(0);
-  const [initialData, setInitialData] = useState<any>(undefined);
-  const [initialDataLoading, setInitialDataLoading] = useState(!!fromWishlistId);
 
   useFocusEffect(
     useCallback(() => {
-      if (!fromWishlistId) {
-        setFormKey(prev => prev + 1);
-      }
-    }, [fromWishlistId])
+      setFormKey(prev => prev + 1);
+    }, [])
   );
-
-  useEffect(() => {
-    if (!fromWishlistId || !token) {
-      setInitialDataLoading(false);
-      return;
-    }
-
-    wishlistService
-      .getWishlistItemById(token, Number(fromWishlistId))
-      .then((item: any) => {
-        setInitialData({
-          bottle: {
-            name: item.bottle.name,
-            domain_name: item.bottle.domain.name,
-            colour_id: item.bottle.colour.id,
-            region_id: item.bottle.region?.id || null,
-            grape_variety_ids: item.bottle.grapeVarieties?.map((gv: any) => gv.id) || [],
-          },
-          ...(item.vintage && { vintage: { year: String(item.vintage.year) } }),
-          appellation_name: item.appellation?.name || "",
-        });
-      })
-      .catch(() => {
-        console.warn("Could not load wishlist item for pre-fill");
-      })
-      .finally(() => {
-        setInitialDataLoading(false);
-      });
-  }, [fromWishlistId, token]);
 
   const handleSubmit = async (formData: any) => {
     if (!token) {
@@ -59,14 +24,6 @@ export default function AddBottlePage() {
 
     try {
       await cellarService.createCellarItem(token, formData);
-
-      if (fromWishlistId) {
-        try {
-          await wishlistService.deleteWishlistItem(token, Number(fromWishlistId));
-        } catch {
-          console.warn("Could not remove wishlist item after adding to cellar");
-        }
-      }
 
       Alert.alert(
         "Succès",
@@ -92,20 +49,11 @@ export default function AddBottlePage() {
     }
   };
 
-  if (initialDataLoading) {
-    return (
-      <View className="flex-1 bg-app items-center justify-center">
-        <ActivityIndicator size="large" color="#730b1e" />
-      </View>
-    );
-  }
-
   return (
     <ScrollView className="flex-1 bg-app">
       <AddOrUpdateBottleForm
         key={formKey}
         mode="add"
-        initialData={initialData}
         onSubmit={handleSubmit}
       />
     </ScrollView>

--- a/cavea-front/app/protected/add-bottle.tsx
+++ b/cavea-front/app/protected/add-bottle.tsx
@@ -33,7 +33,7 @@ export default function AddBottlePage() {
             region_id: item.bottle.region?.id || null,
             grape_variety_ids: item.bottle.grapeVarieties?.map((gv: any) => gv.id) || [],
           },
-          vintage: { year: String(item.vintage.year) },
+          ...(item.vintage && { vintage: { year: String(item.vintage.year) } }),
           appellation_name: item.appellation?.name || "",
         });
       })

--- a/cavea-front/app/protected/add-bottle.tsx
+++ b/cavea-front/app/protected/add-bottle.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, Alert } from "react-native";
+import { ScrollView, Alert, ActivityIndicator, View } from "react-native";
 import { useRouter, useFocusEffect, useLocalSearchParams } from "expo-router";
 import { useState, useCallback, useEffect } from "react";
 import { useAuth } from "@/authentication/AuthContext";
@@ -12,15 +12,21 @@ export default function AddBottlePage() {
   const { fromWishlistId } = useLocalSearchParams<{ fromWishlistId?: string }>();
   const [formKey, setFormKey] = useState(0);
   const [initialData, setInitialData] = useState<any>(undefined);
+  const [initialDataLoading, setInitialDataLoading] = useState(!!fromWishlistId);
 
   useFocusEffect(
     useCallback(() => {
-      setFormKey(prev => prev + 1);
-    }, [])
+      if (!fromWishlistId) {
+        setFormKey(prev => prev + 1);
+      }
+    }, [fromWishlistId])
   );
 
   useEffect(() => {
-    if (!fromWishlistId || !token) return;
+    if (!fromWishlistId || !token) {
+      setInitialDataLoading(false);
+      return;
+    }
 
     wishlistService
       .getWishlistItemById(token, Number(fromWishlistId))
@@ -39,6 +45,9 @@ export default function AddBottlePage() {
       })
       .catch(() => {
         console.warn("Could not load wishlist item for pre-fill");
+      })
+      .finally(() => {
+        setInitialDataLoading(false);
       });
   }, [fromWishlistId, token]);
 
@@ -82,6 +91,14 @@ export default function AddBottlePage() {
       Alert.alert("Erreur", errorMessage);
     }
   };
+
+  if (initialDataLoading) {
+    return (
+      <View className="flex-1 bg-app items-center justify-center">
+        <ActivityIndicator size="large" color="#730b1e" />
+      </View>
+    );
+  }
 
   return (
     <ScrollView className="flex-1 bg-app">

--- a/cavea-front/app/protected/add-bottle.tsx
+++ b/cavea-front/app/protected/add-bottle.tsx
@@ -1,20 +1,46 @@
 import { ScrollView, Alert } from "react-native";
-import { useRouter, useFocusEffect } from "expo-router";
-import { useState, useCallback } from "react";
+import { useRouter, useFocusEffect, useLocalSearchParams } from "expo-router";
+import { useState, useCallback, useEffect } from "react";
 import { useAuth } from "@/authentication/AuthContext";
 import AddOrUpdateBottleForm from "../components/AddOrUpdateBottleForm";
 import { cellarService } from "@/services/CellarService";
+import { wishlistService } from "@/services/WishlistService";
 
 export default function AddBottlePage() {
   const router = useRouter();
   const { token } = useAuth();
+  const { fromWishlistId } = useLocalSearchParams<{ fromWishlistId?: string }>();
   const [formKey, setFormKey] = useState(0);
+  const [initialData, setInitialData] = useState<any>(undefined);
 
   useFocusEffect(
     useCallback(() => {
       setFormKey(prev => prev + 1);
     }, [])
   );
+
+  useEffect(() => {
+    if (!fromWishlistId || !token) return;
+
+    wishlistService
+      .getWishlistItemById(token, Number(fromWishlistId))
+      .then((item: any) => {
+        setInitialData({
+          bottle: {
+            name: item.bottle.name,
+            domain_name: item.bottle.domain.name,
+            colour_id: item.bottle.colour.id,
+            region_id: item.bottle.region?.id || null,
+            grape_variety_ids: item.bottle.grapeVarieties?.map((gv: any) => gv.id) || [],
+          },
+          vintage: { year: String(item.vintage.year) },
+          appellation_name: item.appellation?.name || "",
+        });
+      })
+      .catch(() => {
+        console.warn("Could not load wishlist item for pre-fill");
+      });
+  }, [fromWishlistId, token]);
 
   const handleSubmit = async (formData: any) => {
     if (!token) {
@@ -24,6 +50,14 @@ export default function AddBottlePage() {
 
     try {
       await cellarService.createCellarItem(token, formData);
+
+      if (fromWishlistId) {
+        try {
+          await wishlistService.deleteWishlistItem(token, Number(fromWishlistId));
+        } catch {
+          console.warn("Could not remove wishlist item after adding to cellar");
+        }
+      }
 
       Alert.alert(
         "Succès",
@@ -54,6 +88,7 @@ export default function AddBottlePage() {
       <AddOrUpdateBottleForm
         key={formKey}
         mode="add"
+        initialData={initialData}
         onSubmit={handleSubmit}
       />
     </ScrollView>

--- a/cavea-front/app/protected/add-from-wishlist.tsx
+++ b/cavea-front/app/protected/add-from-wishlist.tsx
@@ -14,7 +14,10 @@ export default function AddFromWishlistPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!id || !token) return;
+    if (!id || !token) {
+      setLoading(false);
+      return;
+    }
 
     wishlistService
       .getWishlistItemById(token, Number(id))

--- a/cavea-front/app/protected/add-from-wishlist.tsx
+++ b/cavea-front/app/protected/add-from-wishlist.tsx
@@ -88,7 +88,11 @@ export default function AddFromWishlistPage() {
   }
 
   return (
-    <ScrollView className="flex-1 bg-app">
+    <ScrollView
+      className="flex-1 bg-app"
+      accessibilityRole="scrollbar"
+      accessibilityLabel="Formulaire d'ajout à la cave depuis la liste de souhaits"
+    >
       <AddOrUpdateBottleForm
         mode="add"
         initialData={initialData}

--- a/cavea-front/app/protected/add-from-wishlist.tsx
+++ b/cavea-front/app/protected/add-from-wishlist.tsx
@@ -1,0 +1,96 @@
+import { ScrollView, Alert, ActivityIndicator, View } from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { useState, useEffect } from "react";
+import { useAuth } from "@/authentication/AuthContext";
+import AddOrUpdateBottleForm from "../components/AddOrUpdateBottleForm";
+import { cellarService } from "@/services/CellarService";
+import { wishlistService } from "@/services/WishlistService";
+
+export default function AddFromWishlistPage() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [initialData, setInitialData] = useState<any>(undefined);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id || !token) return;
+
+    wishlistService
+      .getWishlistItemById(token, Number(id))
+      .then((item: any) => {
+        setInitialData({
+          bottle: {
+            name: item.bottle.name,
+            domain_name: item.bottle.domain.name,
+            colour_id: item.bottle.colour.id,
+            region_id: item.bottle.region?.id || null,
+            grape_variety_ids: item.bottle.grapeVarieties?.map((gv: any) => gv.id) || [],
+          },
+          ...(item.vintage && { vintage: { year: String(item.vintage.year) } }),
+          appellation_name: item.appellation?.name || "",
+        });
+      })
+      .catch(() => {
+        Alert.alert("Erreur", "Impossible de charger les données du vin", [
+          { text: "OK", onPress: () => router.back() },
+        ]);
+      })
+      .finally(() => setLoading(false));
+  }, [id, token]);
+
+  const handleSubmit = async (formData: any) => {
+    if (!token) {
+      Alert.alert("Erreur", "Vous devez être connecté");
+      return;
+    }
+
+    try {
+      await cellarService.createCellarItem(token, formData);
+
+      try {
+        await wishlistService.deleteWishlistItem(token, Number(id));
+      } catch {
+        console.warn("Could not remove wishlist item after adding to cellar");
+      }
+
+      Alert.alert("Succès", "Bouteille ajoutée à votre cave !", [
+        { text: "OK", onPress: () => router.replace("/protected/dashboard") },
+      ]);
+    } catch (error: any) {
+      let errorMessage = "Impossible d'ajouter la bouteille";
+
+      if (error.response?.status === 422) {
+        const validationErrors = error.response.data.errors;
+        errorMessage = Object.values(validationErrors).flat().join("\n");
+      } else {
+        errorMessage = error.message;
+      }
+
+      Alert.alert("Erreur", errorMessage);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View
+        className="flex-1 bg-app items-center justify-center"
+        accessible={true}
+        accessibilityRole="progressbar"
+        accessibilityLabel="Chargement des données du vin"
+      >
+        <ActivityIndicator size="large" color="#730b1e" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-app">
+      <AddOrUpdateBottleForm
+        mode="add"
+        initialData={initialData}
+        onSubmit={handleSubmit}
+      />
+    </ScrollView>
+  );
+}

--- a/cavea-front/app/protected/add-wishlist-item.tsx
+++ b/cavea-front/app/protected/add-wishlist-item.tsx
@@ -1,0 +1,51 @@
+import { ScrollView, Alert } from "react-native";
+import { useRouter } from "expo-router";
+import { useAuth } from "@/authentication/AuthContext";
+import AddOrUpdateBottleForm from "../components/AddOrUpdateBottleForm";
+import { wishlistService } from "@/services/WishlistService";
+
+export default function AddWishlistItemPage() {
+  const router = useRouter();
+  const { token } = useAuth();
+
+  const handleSubmit = async (formData: any) => {
+    if (!token) {
+      Alert.alert("Erreur", "Vous devez être connecté");
+      return;
+    }
+
+    try {
+      await wishlistService.createWishlistItem(token, {
+        bottle: formData.bottle,
+        vintage: formData.vintage,
+        ...(formData.appellation_name && { appellation_name: formData.appellation_name }),
+      });
+
+      Alert.alert(
+        "Succès",
+        "Bouteille ajoutée à votre liste de souhaits !",
+        [{ text: "OK", onPress: () => router.replace("/protected/wishlist") }]
+      );
+    } catch (error: any) {
+      let errorMessage = "Impossible d'ajouter à la liste de souhaits";
+
+      if (error.response?.status === 422) {
+        const validationErrors = error.response.data.errors;
+        errorMessage = Object.values(validationErrors).flat().join("\n");
+      } else {
+        errorMessage = error.message;
+      }
+
+      Alert.alert("Erreur", errorMessage);
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-app">
+      <AddOrUpdateBottleForm
+        mode="wishlist"
+        onSubmit={handleSubmit}
+      />
+    </ScrollView>
+  );
+}

--- a/cavea-front/app/protected/add-wishlist-item.tsx
+++ b/cavea-front/app/protected/add-wishlist-item.tsx
@@ -1,5 +1,6 @@
 import { ScrollView, Alert } from "react-native";
-import { useRouter } from "expo-router";
+import { useRouter, useFocusEffect } from "expo-router";
+import { useState, useCallback } from "react";
 import { useAuth } from "@/authentication/AuthContext";
 import AddOrUpdateBottleForm from "../components/AddOrUpdateBottleForm";
 import { wishlistService } from "@/services/WishlistService";
@@ -7,6 +8,13 @@ import { wishlistService } from "@/services/WishlistService";
 export default function AddWishlistItemPage() {
   const router = useRouter();
   const { token } = useAuth();
+  const [formKey, setFormKey] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      setFormKey(prev => prev + 1);
+    }, [])
+  );
 
   const handleSubmit = async (formData: any) => {
     if (!token) {
@@ -47,6 +55,7 @@ export default function AddWishlistItemPage() {
       accessibilityLabel="Formulaire d'ajout à la liste de souhaits"
     >
       <AddOrUpdateBottleForm
+        key={formKey}
         mode="wishlist"
         onSubmit={handleSubmit}
       />

--- a/cavea-front/app/protected/add-wishlist-item.tsx
+++ b/cavea-front/app/protected/add-wishlist-item.tsx
@@ -17,7 +17,7 @@ export default function AddWishlistItemPage() {
     try {
       await wishlistService.createWishlistItem(token, {
         bottle: formData.bottle,
-        vintage: formData.vintage,
+        ...(formData.vintage && { vintage: formData.vintage }),
         ...(formData.appellation_name && { appellation_name: formData.appellation_name }),
       });
 
@@ -41,7 +41,11 @@ export default function AddWishlistItemPage() {
   };
 
   return (
-    <ScrollView className="flex-1 bg-app">
+    <ScrollView
+      className="flex-1 bg-app"
+      accessibilityRole="scrollbar"
+      accessibilityLabel="Formulaire d'ajout à la liste de souhaits"
+    >
       <AddOrUpdateBottleForm
         mode="wishlist"
         onSubmit={handleSubmit}

--- a/cavea-front/app/protected/wishlist.tsx
+++ b/cavea-front/app/protected/wishlist.tsx
@@ -59,7 +59,7 @@ export default function WishlistPage() {
             if (!token) return;
             try {
               await wishlistService.deleteWishlistItem(token, id);
-              setItems((prev) => prev.filter((i) => i.id !== id));
+              setItems(items.filter((i) => i.id !== id));
             } catch {
               Alert.alert("Erreur", "Impossible de supprimer cet élément");
             }

--- a/cavea-front/app/protected/wishlist.tsx
+++ b/cavea-front/app/protected/wishlist.tsx
@@ -71,8 +71,8 @@ export default function WishlistPage() {
 
   const handleAddToCellar = (id: number) => {
     router.push({
-      pathname: "/protected/add-bottle",
-      params: { fromWishlistId: id },
+      pathname: "/protected/add-from-wishlist",
+      params: { id },
     } as any);
   };
 

--- a/cavea-front/app/protected/wishlist.tsx
+++ b/cavea-front/app/protected/wishlist.tsx
@@ -17,7 +17,7 @@ interface WishlistItem {
     region: { name: string } | null;
     colour: { id: number; name: string };
   };
-  vintage: { year: number };
+  vintage: { year: number } | null;
   appellation: { name: string } | null;
 }
 
@@ -77,21 +77,41 @@ export default function WishlistPage() {
   };
 
   return (
-    <ScrollView className="flex-1 bg-app">
+    <ScrollView
+      className="flex-1 bg-app"
+      accessibilityRole="scrollbar"
+    >
       <OfflineIndicator />
-      <View className="w-full bg-wine px-10 py-14">
-        <View className="w-full items-center my-8">
+
+      <View
+        accessible={true}
+        accessibilityRole="header"
+        accessibilityLabel="Ma liste de souhaits — Les vins qui me font rêver"
+        className="w-full bg-wine px-10 py-14"
+      >
+        <View
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          className="w-full items-center my-8"
+        >
           <Image
             source={require("../../assets/images/logo-fond-rouge.png")}
             style={{ width: "70%", height: 100 }}
+            accessibilityElementsHidden={true}
           />
         </View>
         <PageTitle text="Ma liste de souhaits" color="white" />
-        <Text className="text-white text-lg mb-8">Les vins qui me font rêver !</Text>
+        <Text className="text-white text-lg mb-8">
+          Les vins qui me font rêver !
+        </Text>
       </View>
 
       <View className="px-6 py-6">
-        <View className="mb-4">
+        <View
+          accessible={true}
+          accessibilityRole="none"
+          className="mb-4"
+        >
           <PrimaryButton
             text="Ajouter un vin"
             onPress={() => router.push("/protected/add-wishlist-item" as any)}
@@ -99,11 +119,20 @@ export default function WishlistPage() {
         </View>
 
         {loading ? (
-          <View className="items-center py-10">
+          <View
+            className="items-center py-10"
+            accessible={true}
+            accessibilityRole="progressbar"
+            accessibilityLabel="Chargement de la liste de souhaits"
+          >
             <ActivityIndicator size="large" color="#730b1e" />
           </View>
         ) : items.length > 0 ? (
-          <View className="gap-3">
+          <View
+            accessible={false}
+            accessibilityRole="list"
+            className="gap-3"
+          >
             {items.map((item) => (
               <WishlistCard
                 key={item.id}
@@ -112,15 +141,25 @@ export default function WishlistPage() {
                 domainName={item.bottle.domain.name}
                 region={item.bottle.region?.name || "Région non spécifiée"}
                 colour={item.bottle.colour.name}
-                vintage={item.vintage.year}
+                vintage={item.vintage?.year}
                 onAddToCellar={handleAddToCellar}
                 onDelete={handleDelete}
               />
             ))}
           </View>
         ) : (
-          <View className="items-center justify-center py-16">
-            <Heart color="#730b1e" size={56} strokeWidth={1.5} />
+          <View
+            className="items-center justify-center py-16"
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel="Votre liste de souhaits est vide. Ajoutez des vins pour garder une trace de ceux qui vous font envie."
+          >
+            <Heart
+              color="#730b1e"
+              size={56}
+              strokeWidth={1.5}
+              accessibilityElementsHidden={true}
+            />
             <Text className="text-2xl font-bold text-center mt-6 mb-3">
               Votre liste est vide
             </Text>

--- a/cavea-front/app/protected/wishlist.tsx
+++ b/cavea-front/app/protected/wishlist.tsx
@@ -1,10 +1,84 @@
-import { View, Text, Image } from "react-native";
+import { View, Text, Image, ScrollView, Alert, ActivityIndicator } from "react-native";
 import PageTitle from "../components/PageTitle";
+import WishlistCard from "../components/WishlistCard";
+import PrimaryButton from "../components/PrimaryButton";
+import OfflineIndicator from "../components/OfflineIndicator";
 import { Heart } from "lucide-react-native";
+import { useState, useCallback } from "react";
+import { useRouter, useFocusEffect } from "expo-router";
+import { useAuth } from "@/authentication/AuthContext";
+import { wishlistService } from "@/services/WishlistService";
+
+interface WishlistItem {
+  id: number;
+  bottle: {
+    name: string;
+    domain: { name: string };
+    region: { name: string } | null;
+    colour: { id: number; name: string };
+  };
+  vintage: { year: number };
+  appellation: { name: string } | null;
+}
 
 export default function WishlistPage() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const [items, setItems] = useState<WishlistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchItems = async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const data = await wishlistService.getWishlistItems(token);
+      setItems(data);
+    } catch (error) {
+      console.error("Error loading wishlist:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchItems();
+    }, [token])
+  );
+
+  const handleDelete = (id: number) => {
+    Alert.alert(
+      "Supprimer",
+      "Retirer ce vin de votre liste de souhaits ?",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Supprimer",
+          style: "destructive",
+          onPress: async () => {
+            if (!token) return;
+            try {
+              await wishlistService.deleteWishlistItem(token, id);
+              setItems((prev) => prev.filter((i) => i.id !== id));
+            } catch {
+              Alert.alert("Erreur", "Impossible de supprimer cet élément");
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleAddToCellar = (id: number) => {
+    router.push({
+      pathname: "/protected/add-bottle",
+      params: { fromWishlistId: id },
+    } as any);
+  };
+
   return (
-    <View className="flex-1 bg-app">
+    <ScrollView className="flex-1 bg-app">
+      <OfflineIndicator />
       <View className="w-full bg-wine px-10 py-14">
         <View className="w-full items-center my-8">
           <Image
@@ -13,21 +87,50 @@ export default function WishlistPage() {
           />
         </View>
         <PageTitle text="Ma liste de souhaits" color="white" />
-        <Text className="text-white text-lg mb-8">
-          Les vins qui me font rêver !
-        </Text>
+        <Text className="text-white text-lg mb-8">Les vins qui me font rêver !</Text>
       </View>
 
-      <View className="flex-1 items-center justify-center px-10">
-        <Heart color="#730b1e" size={56} strokeWidth={1.5} />
-        <Text className="text-2xl font-bold text-center mt-6 mb-3">
-          Bientôt disponible
-        </Text>
-        <Text className="text-gray-500 text-center text-base leading-6">
-          Gardez une trace des vins qui vous font envie et ne ratez plus jamais
-          une belle bouteille.
-        </Text>
+      <View className="px-6 py-6">
+        <View className="mb-4">
+          <PrimaryButton
+            text="Ajouter un vin"
+            onPress={() => router.push("/protected/add-wishlist-item" as any)}
+          />
+        </View>
+
+        {loading ? (
+          <View className="items-center py-10">
+            <ActivityIndicator size="large" color="#730b1e" />
+          </View>
+        ) : items.length > 0 ? (
+          <View className="gap-3">
+            {items.map((item) => (
+              <WishlistCard
+                key={item.id}
+                id={item.id}
+                bottleName={item.bottle.name}
+                domainName={item.bottle.domain.name}
+                region={item.bottle.region?.name || "Région non spécifiée"}
+                colour={item.bottle.colour.name}
+                vintage={item.vintage.year}
+                onAddToCellar={handleAddToCellar}
+                onDelete={handleDelete}
+              />
+            ))}
+          </View>
+        ) : (
+          <View className="items-center justify-center py-16">
+            <Heart color="#730b1e" size={56} strokeWidth={1.5} />
+            <Text className="text-2xl font-bold text-center mt-6 mb-3">
+              Votre liste est vide
+            </Text>
+            <Text className="text-gray-500 text-center text-base leading-6">
+              Gardez une trace des vins qui vous font envie et ne ratez plus jamais
+              une belle bouteille.
+            </Text>
+          </View>
+        )}
       </View>
-    </View>
+    </ScrollView>
   );
 }

--- a/cavea-front/services/WishlistService.ts
+++ b/cavea-front/services/WishlistService.ts
@@ -1,0 +1,63 @@
+import { baseURL } from "@/api";
+
+type HttpMethod = 'GET' | 'POST' | 'DELETE';
+
+const buildHeaders = (token: string) => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${token}`,
+});
+
+const fetchAPI = async (
+  endpoint: string,
+  token: string,
+  method: HttpMethod = 'GET',
+  body?: any,
+) => {
+  const response = await fetch(`${baseURL}${endpoint}`, {
+    method,
+    headers: buildHeaders(token),
+    ...(body && { body: JSON.stringify(body) }),
+  });
+
+  if (!response.ok) {
+    let errorData: any = {};
+    try {
+      errorData = await response.json();
+    } catch (_) {}
+    const error = new Error(errorData.message || `Erreur ${method} ${endpoint}`);
+    (error as any).response = { status: response.status, data: errorData };
+    throw error;
+  }
+
+  if (response.status === 204) return null;
+
+  return response.json();
+};
+
+export interface WishlistBottleData {
+  bottle: {
+    name: string;
+    domain_name: string;
+    colour_id: number;
+    region_id: number;
+    grape_variety_ids?: number[];
+  };
+  vintage: {
+    year: number;
+  };
+  appellation_name?: string;
+}
+
+export const wishlistService = {
+  getWishlistItems: (token: string) =>
+    fetchAPI('/wishlist-items', token),
+
+  getWishlistItemById: (token: string, id: number) =>
+    fetchAPI(`/wishlist-items/${id}`, token),
+
+  createWishlistItem: (token: string, data: WishlistBottleData) =>
+    fetchAPI('/wishlist-items', token, 'POST', data),
+
+  deleteWishlistItem: (token: string, id: number) =>
+    fetchAPI(`/wishlist-items/${id}`, token, 'DELETE'),
+};

--- a/cavea-front/services/__tests__/WishlistService.test.ts
+++ b/cavea-front/services/__tests__/WishlistService.test.ts
@@ -1,0 +1,138 @@
+import { wishlistService } from '../WishlistService';
+import { baseURL } from '@/api';
+
+global.fetch = jest.fn();
+
+const mockToken = 'mock-token-123';
+
+const mockOk = (data: any, status = 200) =>
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    status,
+    json: async () => data,
+  });
+
+const mockError = (status: number, message = 'Error') =>
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => ({ message }),
+  });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('WishlistService - getWishlistItems', () => {
+  it('should return the list of wishlist items', async () => {
+    const mockData = [{ id: 1, bottle: { name: 'Test' } }];
+    mockOk(mockData);
+
+    const result = await wishlistService.getWishlistItems(mockToken);
+
+    expect(result).toEqual(mockData);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseURL}/wishlist-items`,
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Authorization: `Bearer ${mockToken}` }),
+      })
+    );
+  });
+
+  it('should throw on API error', async () => {
+    mockError(401);
+    await expect(wishlistService.getWishlistItems(mockToken)).rejects.toThrow();
+  });
+});
+
+describe('WishlistService - getWishlistItemById', () => {
+  it('should return a single wishlist item by id', async () => {
+    const mockData = { id: 5, bottle: { name: 'Wine' } };
+    mockOk(mockData);
+
+    const result = await wishlistService.getWishlistItemById(mockToken, 5);
+
+    expect(result).toEqual(mockData);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseURL}/wishlist-items/5`,
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('should throw 404 when not found', async () => {
+    mockError(404, 'Not found');
+    await expect(wishlistService.getWishlistItemById(mockToken, 999)).rejects.toThrow();
+  });
+});
+
+describe('WishlistService - createWishlistItem', () => {
+  const payload = {
+    bottle: {
+      name: 'Château Test',
+      domain_name: 'Domaine Test',
+      colour_id: 1,
+      region_id: 2,
+    },
+    vintage: { year: 2020 },
+  };
+
+  it('should POST and return the created wishlist item', async () => {
+    const created = { id: 10, ...payload };
+    mockOk(created, 201);
+
+    const result = await wishlistService.createWishlistItem(mockToken, payload);
+
+    expect(result).toEqual(created);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseURL}/wishlist-items`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${mockToken}`,
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+  });
+
+  it('should throw validation error on 422', async () => {
+    mockError(422, 'Les données fournies ne sont pas valides');
+    await expect(wishlistService.createWishlistItem(mockToken, payload)).rejects.toThrow(
+      'Les données fournies ne sont pas valides'
+    );
+  });
+
+  it('should include appellation_name when provided', async () => {
+    const payloadWithApp = { ...payload, appellation_name: 'AOP Languedoc' };
+    mockOk({ id: 11, ...payloadWithApp }, 201);
+
+    await wishlistService.createWishlistItem(mockToken, payloadWithApp);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify(payloadWithApp) })
+    );
+  });
+});
+
+describe('WishlistService - deleteWishlistItem', () => {
+  it('should DELETE the wishlist item and return null', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, status: 204 });
+
+    const result = await wishlistService.deleteWishlistItem(mockToken, 7);
+
+    expect(result).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseURL}/wishlist-items/7`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({ Authorization: `Bearer ${mockToken}` }),
+      })
+    );
+  });
+
+  it('should throw 403 when not authorized', async () => {
+    mockError(403, 'Forbidden');
+    await expect(wishlistService.deleteWishlistItem(mockToken, 7)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Résumé

- **Liste de souhaits complète** : page wishlist alimentée (liste, état vide, suppression avec confirmation), ajout d'un vin via un formulaire dédié (sans les champs stock/prix/achat)
- **Ajout à la cave depuis la wishlist** : bouton "Ajouter à ma cave" sur chaque carte, qui pré-remplit le formulaire existant avec les infos du vin et supprime automatiquement l'item de la wishlist après validation
- **Millésime optionnel** sur la wishlist : on peut ajouter un vin à sa liste sans connaître le millésime
- **Accessibilité** : `accessibilityRole`, `accessibilityLabel` et `accessibilityHint` sur tous les éléments interactifs et structurants des nouvelles pages ; éléments décoratifs masqués
- **CI/CD** : les branches `claude/**` déclenchent désormais lint + tests + SonarQube (comme `feature/**`)

## Détail technique

### Backend
- Migration `wishlist_items` (`user_id`, `bottle_id`, `vintage_id` nullable, `appellation_id` nullable)
- `WishlistItem` model + factory + `WishlistItemPolicy`
- `WishlistService` (getUserItems, findByIdAndUser, create, delete)
- `WishlistController` — `GET/POST /wishlist-items`, `GET/DELETE /wishlist-items/{id}`
- Réutilise `BottleService`, `VintageService`, `DomainService`, `AppellationService`

### Frontend
- `WishlistService.ts` — appels API
- `WishlistCard` — carte avec boutons accessibles
- `add-wishlist-item.tsx` — écran d'ajout (mode `wishlist` du formulaire existant)
- `AddOrUpdateBottleForm` — nouveau mode `'wishlist'` (sections achat/dégustation masquées, millésime optionnel)
- `add-bottle.tsx` — gère le paramètre `fromWishlistId` pour pré-remplir depuis la wishlist

## Plan de test

- [ ] Ajouter un vin à la wishlist (avec et sans millésime)
- [ ] Vérifier l'affichage de la liste et de l'état vide
- [ ] Supprimer un vin de la wishlist
- [ ] Cliquer "Ajouter à ma cave" → vérifier que le formulaire est pré-rempli
- [ ] Valider l'ajout en cave → vérifier que le vin disparaît de la wishlist et apparaît dans la cave
- [ ] Tester avec un lecteur d'écran (VoiceOver / TalkBack) sur les nouvelles pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYTajf1488ZCDGYj3EzDpD)_